### PR TITLE
Mob printers no longer care if you can re-enter corpse

### DIFF
--- a/code/game/machinery/martian_printer.dm
+++ b/code/game/machinery/martian_printer.dm
@@ -21,15 +21,11 @@
 		to_chat(O, "<span class='warning'>Error: printer still recharging. Time left: [round((cooldown_time - world.time + 20)/10)] seconds.</span>")
 		return
 
-	if(O.can_reenter_corpse)
-		if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
-			if(building)
-				to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")
-				return
-		else
+	if(alert(O,"Do you want to enter a corporeal form?","Inset Disk","Yes","No")== "Yes")
+		if(building)
+			to_chat(O, "<span class='notice'>\The [src] is already processing another. Try again later.</span>")
 			return
-	else if(!(O.can_reenter_corpse))
-		to_chat(O,"<span class='notice'>You have recently ghosted and can not enter right now. Try again later.</span>")
+	else
 		return
 
 	make_mob(O)


### PR DESCRIPTION
Mob printers no longer check to see if you can re-enter corpse. This is probably sensible sanity but since it's an adminbus piece of machinery, and it breaks under some very annoying circumstances (for instance, if you run into the bluespace in Lamprey Hell) then it's preferable to just let people respawn as something more often than not.

Tested locally but web editor used because I am more lazy than responsible. Sue me at my home address

:cl:
 * bugfix: You can now fall into the pits of Hell and become a lawyer again!